### PR TITLE
Sys info

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "files.associations": {
+    "param.h": "c",
+    "defs.h": "c",
+    "info.h": "c",
+    "memlayout.h": "c",
+    "proc.h": "c"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
   "files.associations": {
-    "param.h": "c",
-    "defs.h": "c",
     "info.h": "c",
-    "memlayout.h": "c",
-    "proc.h": "c"
+    "user.h": "c",
+    "defs.h": "c",
+    "riscv.h": "c",
+    "types.h": "c"
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,10 @@ OBJS = \
   $K/pipe.o \
   $K/exec.o \
   $K/sysfile.o \
+	$K/sysinfo.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+	$U/_sysinfotest\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -63,6 +63,7 @@ void            ramdiskrw(struct buf*);
 void*           kalloc(void);
 void            kfree(void *);
 void            kinit(void);
+int             freemem(void);
 
 // log.c
 void            initlog(int, struct superblock*);
@@ -106,7 +107,7 @@ void            yield(void);
 int             either_copyout(int user_dst, uint64 dst, void *src, uint64 len);
 int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
-
+int             nproc(void);
 // swtch.S
 void            swtch(struct context*, struct context*);
 

--- a/kernel/info.h
+++ b/kernel/info.h
@@ -1,0 +1,4 @@
+struct sysinfo {
+  int freemem;
+  int nproc;
+};

--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -96,7 +96,7 @@ freemem(void)
 
   while (r) {
     total+=PGSIZE;
-    kmem.freelist = r->next;
+    r = r->next;
   }
 
   return total;

--- a/kernel/kalloc.c
+++ b/kernel/kalloc.c
@@ -80,3 +80,24 @@ kalloc(void)
     memset((char*)r, 5, PGSIZE); // fill with junk
   return (void*)r;
 }
+
+// returns the amount of bytes that are free (unallocated)
+// total = number of free pages * PGSIZE
+int
+freemem(void)
+{
+  struct run *r;
+  int total = 0;
+  r = kmem.freelist;
+
+  // kmem.freelist should not be null at this point
+  if(!r)
+    panic("kalloc: kmem.freelist is null");
+
+  while (r) {
+    total+=PGSIZE;
+    kmem.freelist = r->next;
+  }
+
+  return total;
+}

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -681,3 +681,19 @@ procdump(void)
     printf("\n");
   }
 }
+
+// list all processes that are not unused
+
+int
+nproc(void)
+{
+  struct proc *p;
+  int count = 0;
+  for(p = proc; p < &proc[NPROC]; p++){
+    if (p->state == UNUSED)
+      continue;
+    count++;
+  }
+
+  return count;
+}

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_info(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_info]    sys_info,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_info   22

--- a/kernel/sysinfo.c
+++ b/kernel/sysinfo.c
@@ -2,6 +2,8 @@
 #include "riscv.h"
 #include "info.h"
 #include "defs.h"
+#include "param.h"
+#include "spinlock.h"
 #include "proc.h"
 
 uint64

--- a/kernel/sysinfo.c
+++ b/kernel/sysinfo.c
@@ -1,0 +1,20 @@
+#include "types.h"
+#include "riscv.h"
+#include "info.h"
+#include "defs.h"
+#include "proc.h"
+
+uint64
+sys_info(void)
+{
+  uint64 si;  // user pointer to struct sysinfo
+  argaddr(0, &si);
+
+  struct proc *p = myproc();
+  struct sysinfo ksi; // kernel struct sysinfo
+  ksi.nproc = nproc();
+  ksi.freemem = freemem();
+  if (copyout(p->pagetable, si, (char *)&ksi, sizeof(ksi)) < 0)
+    return -1;
+  return 0;
+}

--- a/user/sysinfotest.c
+++ b/user/sysinfotest.c
@@ -1,0 +1,15 @@
+#include "kernel/types.h"
+#include "kernel/info.h"
+#include "user.h"
+
+struct sysinfo;
+
+int
+main(int argc, char *argv[])
+{
+  struct sysinfo si;
+  info(&si);
+  printf("nproc: %d\nfreemem: %d\n", si.nproc, si.freemem);
+
+  exit(0);
+}

--- a/user/sysinfotest.c
+++ b/user/sysinfotest.c
@@ -9,7 +9,7 @@ main(int argc, char *argv[])
 {
   struct sysinfo si;
   info(&si);
-  printf("nproc: %d\nfreemem: %d\n", si.nproc, si.freemem);
+  printf("nproc: %d\nfreemem: %d bytes\n", si.nproc, si.freemem);
 
   exit(0);
 }

--- a/user/user.h
+++ b/user/user.h
@@ -1,4 +1,5 @@
 struct stat;
+struct sysinfo;
 
 // system calls
 int fork(void);
@@ -22,6 +23,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int info(struct sysinfo*);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("info");


### PR DESCRIPTION
Exercise: In this assignment you will add a system call, `info`, that collects information about the running system. The system call takes one argument: a pointer to a `struct sysinfo`. The kernel should fill out the fields of this struct: the `freemem` field should be set to the number of bytes of free memory, and the `nproc` field should be set to the number of processes whose state is not `UNUSED`.

Files changed:
kernel:
- `defs.h`: added function declarations for `freemem` and `nproc`.
- `sysinfo.c`: syscall handler for `info` called `sys_info` implementation.
- `info.h`: defenition for `struct sysinfo`.
- `syscall.c`: added function declaration for `info` syscall handler (`sys_info`), and mapped a syscall number to it.
- `syscall.h`: added syscall number preprocessor defenition.
- `proc.c`: added a function to get number of non-unused processes (`nproc`).
- `kalloc.c`: added a function to get number of free bytes available (`freemem`).

user:
- `sysinfotest.c`: currently just prints out output of `info` syscall
- `usys.pl`: added "info" entry
- `user.h`: added function decleration for `void info(struct sysinfo*)` syscall wrapper.

## How did I implement `nproc`?
Go through the process table and count processes with statuses that are not `UNUSED`

## How did I implement `freemem`?
Iterated through the kernel "freelist" —which is a linked list that links together free pages of memory that transforms the memory itself into a data structure that keeps track of free pages— and add `PGSIZE` (4096) bytes to the total value each time, which should give us the total free memory.

## What's missing?
- I don't know how to validate the functionality
- What are some security features I should consider?
- What are some error states that could happen that I am not handling?